### PR TITLE
Create ApplicationDbContext.cs

### DIFF
--- a/VoluntariadoConectadoRD.Data/ApplicationDbContext.cs
+++ b/VoluntariadoConectadoRD.Data/ApplicationDbContext.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+using VoluntariadoApi.Models;
+
+namespace VoluntariadoApi.Data
+{
+    public class ApplicationDbContext : DbContext
+    {
+        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)
+        {
+        }
+
+        public DbSet<Oportunidad> Oportunidades { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            // Configuraciones adicionales si son necesarias
+            modelBuilder.Entity<Oportunidad>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Titulo).IsRequired().HasMaxLength(200);
+                entity.Property(e => e.Descripcion).IsRequired().HasMaxLength(1000);
+                entity.Property(e => e.Ubicacion).IsRequired().HasMaxLength(150);
+                entity.Property(e => e.Tipo).IsRequired().HasMaxLength(50);
+                entity.Property(e => e.FechaInicio).IsRequired();
+                entity.Property(e => e.FechaFin).IsRequired();
+            });
+        }
+    }
+}


### PR DESCRIPTION
Esta solicitud de extracción presenta la clase `ApplicationDBContext` para configurar el contexto de la base de datos de Entity Framework Core para la aplicación. Incluye la configuración de la entidad 'Oportunidad', especificando sus propiedades y restricciones.

### Configuración de contexto de la base de datos:

* Se agregó la clase `AplicationDBContext` en` voluntariaConectAdord.
Data/ApplicationDBContext.cs` para definir el contexto de la base de datos. Incluye una propiedad `dbset <Oportunidad>` para administrar las entidades `Oportunidad` y anula 'onModelCreating` para configurar el esquema de la entidad. Las configuraciones clave incluyen la configuración de los campos requeridos, las longitudes máximas y la clave principal para la entidad 'Oportunidad`.