### PR TITLE
Remove workflow timeout and extend JWT expiration

### DIFF
--- a/.github/workflows/swagger-live.yml
+++ b/.github/workflows/swagger-live.yml
@@ -9,7 +9,6 @@ permissions:
 jobs:
   preview:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
      
     env:
       PORT: 5000   
@@ -88,7 +87,7 @@ jobs:
 
     # ── keep it up for reviewers, then clean up ────────────────────────
     - name: Keep tunnel open
-      run: sleep 1800          # 30 min, adjust as needed
+      run: sleep 259200          # 30 min, adjust as needed
 
     - if: always()
       run: kill $(cat api.pid) || true

--- a/VoluntariadoConectadoRD/appsettings.json
+++ b/VoluntariadoConectadoRD/appsettings.json
@@ -6,7 +6,7 @@
     "SecretKey": "VoluntariadoConectadoRD-Super-Secret-Key-256-bits-long-for-security",
     "Issuer": "VoluntariadoConectadoRD",
     "Audience": "VoluntariadoConectadoRD-Users",
-    "ExpirationMinutes": "60"
+    "ExpirationMinutes": "525600"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
- Remove GitHub Actions workflow timeout limit
- Extend tunnel duration to 72 hours for PR previews
- Increase JWT token expiration to 1 year (525600 minutes)